### PR TITLE
Add lsb support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ rust:
   - stable
   - beta
   - nightly
-script: cargo build --verbose
 matrix:
   allow_failures:
     - rust: nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "os_type"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Jan Schulte <hello@unexpected-co.de>"]
 license = "MIT"
 description = "Detect the operating system type"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,5 @@ authors = ["Jan Schulte <hello@unexpected-co.de>"]
 license = "MIT"
 description = "Detect the operating system type"
 repository = "https://github.com/schultyy/os_type"
+[dependencies]
+regex="0.1.41"

--- a/README.md
+++ b/README.md
@@ -25,8 +25,14 @@ fn foo() {
 }
 ```
 
-Note that right now it detects only `OS X` and `RedHat/CentOS`. If you need support for more OS types,
-I am looking forward to your Pull Request.
+Right now, the following operating systems are detected:
+
+- Mac OS X
+- CentOS
+- RedHat
+- Ubuntu
+
+If you need support for more OS types, I am looking forward to your Pull Request.
 
 ## License
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,12 +2,14 @@ use std::process::Command;
 use std::fs;
 use std::convert::AsRef;
 use std::path::Path;
+mod lsb_release;
 
 #[derive(Debug)]
 pub enum OSType {
     Unknown,
     Redhat,
-    OSX
+    OSX,
+    Ubuntu
 }
 
 fn file_exists<P: AsRef<Path>>(path: P) -> bool {
@@ -20,16 +22,38 @@ fn file_exists<P: AsRef<Path>>(path: P) -> bool {
 }
 
 fn is_os_x() -> bool {
-    let output = Command::new("sw_vers").output().unwrap();
-    output.status.success()
+    match Command::new("sw_vers").output() {
+        Ok(output) => output.status.success(),
+        Err(_) => false
+    }
+}
+
+fn lsb_release() -> OSType {
+    match lsb_release::from_file("/etc/lsb-release") {
+        Ok(release) => {
+            if release.distro == Some("Ubuntu".to_string()) {
+                OSType::Ubuntu
+            }
+            else {
+                OSType::Unknown
+            }
+        },
+        Err(_) => OSType::Unknown
+    }
+
 }
 
 pub fn current_platform() -> OSType {
-    if file_exists("/etc/redhat-release") || file_exists("/etc/centos-release") {
-        OSType::Redhat
-    } else if is_os_x() {
+    if is_os_x() {
         OSType::OSX
-    } else {
+    }
+    else if file_exists("/etc/lsb-release") {
+        lsb_release()
+    }
+    else if file_exists("/etc/redhat-release") || file_exists("/etc/centos-release") {
+        OSType::Redhat
+    }
+    else {
         OSType::Unknown
     }
 }

--- a/src/lsb_release.rs
+++ b/src/lsb_release.rs
@@ -14,7 +14,6 @@ pub fn parse(file: String) -> LsbRelease {
         Some(m) => {
             match m.at(1) {
                 Some(distro) => {
-                    println!("Match {}", distro);
                     Some(distro.to_string())
                 },
                 None => None

--- a/src/lsb_release.rs
+++ b/src/lsb_release.rs
@@ -1,0 +1,40 @@
+extern crate regex;
+use self::regex::Regex;
+
+pub struct LsbRelease {
+    pub distro: Option<String>,
+    pub version: Option<String>
+}
+
+pub fn parse(file: String) -> LsbRelease {
+    let distrib_regex = Regex::new(r"DISTRIB_ID=(\w+)").unwrap();
+    let distrib_release_regex = Regex::new(r"DISTRIB_RELEASE=([\w\.]+)").unwrap();
+
+    let distro = match distrib_regex.captures_iter(&file).next() {
+        Some(m) => {
+            match m.at(1) {
+                Some(distro) => {
+                    println!("Match {}", distro);
+                    Some(distro.to_string())
+                },
+                None => None
+            }
+        },
+        None => None
+    };
+
+    let version = match distrib_release_regex.captures_iter(&file).next() {
+        Some(m) => {
+            match m.at(1) {
+                Some(version) => Some(version.to_string()),
+                None => None
+            }
+        },
+        None => None
+    };
+
+    LsbRelease {
+        distro: distro,
+        version: version
+    }
+}

--- a/src/lsb_release.rs
+++ b/src/lsb_release.rs
@@ -1,9 +1,27 @@
 extern crate regex;
 use self::regex::Regex;
+use std::io::prelude::*;
+use std::fs::File;
+use std::convert::AsRef;
+use std::path::Path;
+use std::io::Error;
 
 pub struct LsbRelease {
     pub distro: Option<String>,
     pub version: Option<String>
+}
+
+pub fn from_file<P: AsRef<Path>>(path: P) -> Result<LsbRelease, Error> {
+    let mut handle = match File::open(path) {
+        Ok(h) => h,
+        Err(err) => return Err(err)
+    };
+
+    let mut file_content = String::new();
+
+    handle.read_to_string(&mut file_content);
+    let release = parse(file_content);
+    Ok(release)
 }
 
 pub fn parse(file: String) -> LsbRelease {

--- a/tests/lsb_release_test.rs
+++ b/tests/lsb_release_test.rs
@@ -1,0 +1,23 @@
+#[path="../src/lsb_release.rs"]
+mod lsb_release;
+
+fn file() -> String {
+"
+    DISTRIB_ID=Ubuntu
+    DISTRIB_RELEASE=14.04
+    DISTRIB_CODENAME=trusty
+    DISTRIB_DESCRIPTION=\"Ubuntu 14.04.2 LTS\"
+    ".to_string()
+}
+
+#[test]
+pub fn test_parses_lsb_distro() {
+    let parse_results = lsb_release::parse(file());
+    assert_eq!(parse_results.distro, Some("Ubuntu".to_string()));
+}
+
+#[test]
+pub fn test_parses_lsb_version() {
+    let parse_results = lsb_release::parse(file());
+    assert_eq!(parse_results.version, Some("14.04".to_string()));
+}


### PR DESCRIPTION
This PR adds support for `lsb-release`. That allows to detect Ubuntu systems.