### PR TITLE
Add debian support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,8 @@ pub enum OSType {
     Unknown,
     Redhat,
     OSX,
-    Ubuntu
+    Ubuntu,
+    Debian
 }
 
 fn file_exists<P: AsRef<Path>>(path: P) -> bool {
@@ -31,16 +32,19 @@ fn is_os_x() -> bool {
 }
 
 fn lsb_release() -> OSType {
-    match lsb_release::from_file("/etc/lsb-release") {
-        Ok(release) => {
+    match lsb_release::retrieve() {
+        Some(release) => {
             if release.distro == Some("Ubuntu".to_string()) {
                 OSType::Ubuntu
+            }
+            else if release.distro == Some("Debian".to_string()) {
+                OSType::Debian
             }
             else {
                 OSType::Unknown
             }
         },
-        Err(_) => OSType::Unknown
+        None => OSType::Unknown
     }
 
 }
@@ -57,7 +61,7 @@ pub fn current_platform() -> OSType {
     if is_os_x() {
         OSType::OSX
     }
-    else if file_exists("/etc/lsb-release") {
+    else if lsb_release::is_available() {
         lsb_release()
     }
     else if file_exists("/etc/redhat-release") || file_exists("/etc/centos-release") {

--- a/src/lsb_release.rs
+++ b/src/lsb_release.rs
@@ -5,10 +5,27 @@ use std::fs::File;
 use std::convert::AsRef;
 use std::path::Path;
 use std::io::Error;
+use std::process::Command;
 
 pub struct LsbRelease {
     pub distro: Option<String>,
     pub version: Option<String>
+}
+
+pub fn retrieve() -> Option<LsbRelease> {
+    let output = match Command::new("lsb_release").arg("-a").output() {
+        Ok(o)  => o,
+        Err(_) =>return None
+    };
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Some(parse(stdout.to_string()))
+}
+
+pub fn is_available() -> bool {
+    match Command::new("lsb_release").output() {
+        Ok(_) => true,
+        Err(_) => false
+    }
 }
 
 pub fn from_file<P: AsRef<Path>>(path: P) -> Result<LsbRelease, Error> {
@@ -31,8 +48,8 @@ pub fn from_file<P: AsRef<Path>>(path: P) -> Result<LsbRelease, Error> {
 }
 
 pub fn parse(file: String) -> LsbRelease {
-    let distrib_regex = Regex::new(r"DISTRIB_ID=(\w+)").unwrap();
-    let distrib_release_regex = Regex::new(r"DISTRIB_RELEASE=([\w\.]+)").unwrap();
+    let distrib_regex = Regex::new(r"Distributor ID:\s(\w+)").unwrap();
+    let distrib_release_regex = Regex::new(r"Release:\s([\w\.]+)").unwrap();
 
     let distro = match distrib_regex.captures_iter(&file).next() {
         Some(m) => {

--- a/src/lsb_release.rs
+++ b/src/lsb_release.rs
@@ -1,10 +1,5 @@
 extern crate regex;
 use self::regex::Regex;
-use std::io::prelude::*;
-use std::fs::File;
-use std::convert::AsRef;
-use std::path::Path;
-use std::io::Error;
 use std::process::Command;
 
 pub struct LsbRelease {

--- a/src/lsb_release.rs
+++ b/src/lsb_release.rs
@@ -28,25 +28,6 @@ pub fn is_available() -> bool {
     }
 }
 
-pub fn from_file<P: AsRef<Path>>(path: P) -> Result<LsbRelease, Error> {
-    let mut handle = match File::open(path) {
-        Ok(h) => h,
-        Err(err) => return Err(err)
-    };
-
-    let mut file_content = String::new();
-
-    match handle.read_to_string(&mut file_content) {
-        Ok(_) => {
-            let release = parse(file_content);
-            Ok(release)
-        },
-        Err(err) => {
-            Err(err)
-        }
-    }
-}
-
 pub fn parse(file: String) -> LsbRelease {
     let distrib_regex = Regex::new(r"Distributor ID:\s(\w+)").unwrap();
     let distrib_release_regex = Regex::new(r"Release:\s([\w\.]+)").unwrap();

--- a/tests/lsb_release_test.rs
+++ b/tests/lsb_release_test.rs
@@ -3,21 +3,21 @@ mod lsb_release;
 
 fn file() -> String {
 "
-    DISTRIB_ID=Ubuntu
-    DISTRIB_RELEASE=14.04
-    DISTRIB_CODENAME=trusty
-    DISTRIB_DESCRIPTION=\"Ubuntu 14.04.2 LTS\"
-    ".to_string()
+Distributor ID:	Debian
+Description:	Debian GNU/Linux 7.8 (wheezy)
+Release:	7.8
+Codename:	wheezy
+".to_string()
 }
 
 #[test]
 pub fn test_parses_lsb_distro() {
     let parse_results = lsb_release::parse(file());
-    assert_eq!(parse_results.distro, Some("Ubuntu".to_string()));
+    assert_eq!(parse_results.distro, Some("Debian".to_string()));
 }
 
 #[test]
 pub fn test_parses_lsb_version() {
     let parse_results = lsb_release::parse(file());
-    assert_eq!(parse_results.version, Some("14.04".to_string()));
+    assert_eq!(parse_results.version, Some("7.8".to_string()));
 }


### PR DESCRIPTION
Add support for Debian

To make this possible, `lsb_release` is now called instead reading `/etc/lsb-release`, because that file is not existant on Debian.