### PR TITLE
0.7.0 Move distros to a HashSet,Impl Display and To_String for OSType,take apart redhat and centos,Complete top 10 distributions on distrowatch.com.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.6.0"
 authors = ["Jan Schulte <hello@unexpected-co.de>"]
 license = "MIT"
 description = "Detect the operating system type"
+keywords = ["os_type","ostype","os_name","osname","platform"]
 repository = "https://github.com/schultyy/os_type"
 [dependencies]
 regex="0.1.41"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "os_type"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Jan Schulte <hello@unexpected-co.de>"]
 license = "MIT"
 description = "Detect the operating system type"

--- a/README.md
+++ b/README.md
@@ -3,13 +3,18 @@
 # os_type
 Rust library to detect the operating system type
 
+## Explain  
+`os_type::current_platform()` return a enum.   
+
+impl  `Debug, Display , To_String` for the enum.
+
 ## Usage
 
 Include this into your `Cargo.toml`:
 
 ```toml
 [dependencies]
-os_type="0.5.0"
+os_type="0.7.0"
 ```
 
 In your code:
@@ -17,8 +22,13 @@ In your code:
 ```rust
 extern crate os_type;
 
-fn foo() {
-    match format!("{}", os_type::current_platform()).as_ref() {
+fn main() {
+    println!("Current OS test:");
+    println!("Debug: {:?}", os_type::current_platform());
+    println!("Display: {}", os_type::current_platform());
+    let os_type = os_type::current_platform().to_string();
+    println!("to_string: {}", os_type);
+    match os_type::current_platform().to_string().as_ref() {
         os @ "Windows" => {
             // Do something here
         }
@@ -26,7 +36,6 @@ fn foo() {
         os @ "openSUSE" => {}        
         os @ _ => {}
     };
-    println!("os_type: {}", os_type::current_platform());
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ Right now, the following operating systems are detected:
 - RedHat
 - Ubuntu
 - openSUSE
+- Mint
+- Manjaro
+- elementary
+- Fedora
+- Zorin
+- deepin
 
 If you need support for more OS types, I am looking forward to your Pull Request.
 

--- a/README.md
+++ b/README.md
@@ -18,18 +18,15 @@ In your code:
 extern crate os_type;
 
 fn foo() {
-      match os_type::current_platform() {
-        os_type::OSType::Windows => {
-            // Do something here ...
+    match format!("{}", os_type::current_platform()).as_ref() {
+        os @ "Windows" => {
+            // Do something here
         }
-        os_type::OSType::OSX => {
-            // Do something here ...
-        }
-        os_type::OSType::Distro("openSUSE") =>{
-             // Do something here ...
-        },
-        _ => {}
+        os @ "OSX" => {}
+        os @ "openSUSE" => {}        
+        os @ _ => {}
     };
+    println!("os_type: {}", os_type::current_platform());
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,15 +19,24 @@ extern crate os_type;
 
 fn foo() {
       match os_type::current_platform() {
-        os_type::OSType::OSX => /*Do something here*/,
-        _ => None
-    }
+        os_type::OSType::Windows => {
+            // Do something here ...
+        }
+        os_type::OSType::OSX => {
+            // Do something here ...
+        }
+        os_type::OSType::Distro("openSUSE") =>{
+             // Do something here ...
+        },
+        _ => {}
+    };
 }
 ```
 
 Right now, the following operating systems are detected:
 
 - Mac OS X
+- Windows
 - CentOS
 - RedHat
 - Ubuntu

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Right now, the following operating systems are detected:
 - CentOS
 - RedHat
 - Ubuntu
+- openSUSE
 
 If you need support for more OS types, I am looking forward to your Pull Request.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,8 @@ use std::path::Path;
 mod lsb_release;
 mod windows_ver;
 
-///A list of supported operating system types
+/// A list of supported operating system types
+#[allow(non_camel_case_types)]
 #[derive(Debug)]
 #[derive(PartialEq)]
 #[derive(Clone)]
@@ -17,6 +18,7 @@ pub enum OSType {
     Debian,
     Windows,
     Arch,
+    openSUSE, // Is 'openSUSE' instead of 'OpenSUSE'.
 }
 
 fn file_exists<P: AsRef<Path>>(path: P) -> bool {
@@ -24,12 +26,12 @@ fn file_exists<P: AsRef<Path>>(path: P) -> bool {
 
     match metadata {
         Ok(md) => md.is_dir() || md.is_file(),
-        Err(_) => false
+        Err(_) => false,
     }
 }
 
 fn is_windows() -> bool {
-    if cfg!(target_os="windows") {
+    if cfg!(target_os = "windows") {
         return true;
     } else {
         return false;
@@ -39,7 +41,7 @@ fn is_windows() -> bool {
 fn is_os_x() -> bool {
     match Command::new("sw_vers").output() {
         Ok(output) => output.status.success(),
-        Err(_) => false
+        Err(_) => false,
     }
 }
 
@@ -48,43 +50,39 @@ fn lsb_release() -> OSType {
         Some(release) => {
             if release.distro == Some("Ubuntu".to_string()) {
                 OSType::Ubuntu
-            }
-            else if release.distro == Some("Debian".to_string()) {
+            } else if release.distro == Some("Debian".to_string()) {
                 OSType::Debian
             } else if release.distro == Some("Arch".to_string()) {
                 OSType::Arch
-            }
-            else {
+            } else if release.distro == Some("openSUSE".to_string()) {
+                OSType::openSUSE
+            } else {
                 OSType::Unknown
             }
-        },
-        None => OSType::Unknown
+        }
+        None => OSType::Unknown,
     }
 
 }
 
-///Returns the current operating system type
+/// Returns the current operating system type
 ///
-///#Example
+/// #Example
 ///
-///```
-///use os_type;
-///let os = os_type::current_platform();
-///```
+/// ```
+/// use os_type;
+/// let os = os_type::current_platform();
+/// ```
 pub fn current_platform() -> OSType {
     if is_os_x() {
         OSType::OSX
-    }
-    else if is_windows() {
+    } else if is_windows() {
         OSType::Windows
-    }
-    else if lsb_release::is_available() {
+    } else if lsb_release::is_available() {
         lsb_release()
-    }
-    else if file_exists("/etc/redhat-release") || file_exists("/etc/centos-release") {
+    } else if file_exists("/etc/redhat-release") || file_exists("/etc/centos-release") {
         OSType::Redhat
-    }
-    else {
+    } else {
         OSType::Unknown
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,6 @@ mod lsb_release;
 mod windows_ver;
 
 /// A list of supported operating system types
-#[allow(non_camel_case_types)]
 #[derive(Debug)]
 #[derive(PartialEq)]
 #[derive(Clone)]
@@ -25,7 +24,7 @@ pub enum OSType {
 impl fmt::Display for OSType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            OSType::Windows => write!(f, "windows")?,
+            OSType::Windows => write!(f, "Windows")?,
             OSType::OSX => write!(f, "OSX")?,
             OSType::Distro(distro) => write!(f, "{}", distro)?,
             OSType::Redhat => write!(f, "RedHat")?,
@@ -33,6 +32,18 @@ impl fmt::Display for OSType {
             OSType::Unknown => write!(f, "Unknown")?,            
         };
         Ok(())
+    }
+}
+
+// conflicting implementations of trait `std::string::ToString` for type `OSType` in crate `collections`
+// so use 'To_String' to void.
+#[allow(non_camel_case_types)]
+trait To_String {
+    fn to_string(&self) -> String;
+}
+impl To_String for OSType {
+    fn to_string(&self) -> String {
+        format!("{}", self)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,12 @@ pub enum OSType {
     Windows,
     Arch,
     openSUSE, // Is 'openSUSE' instead of 'OpenSUSE'.
+    Mint,
+    Manjaro,
+    elementary,
+    Fedora,
+    Zorin,
+    deepin,
 }
 
 fn file_exists<P: AsRef<Path>>(path: P) -> bool {
@@ -56,6 +62,18 @@ fn lsb_release() -> OSType {
                 OSType::Arch
             } else if release.distro == Some("openSUSE".to_string()) {
                 OSType::openSUSE
+            } else if release.distro == Some("Manjaro".to_string()) {
+                OSType::Manjaro
+            } else if release.distro == Some("Mint".to_string()) {
+                OSType::Mint
+            } else if release.distro == Some("elementary".to_string()) {
+                OSType::elementary
+            } else if release.distro == Some("Fedora".to_string()) {
+                OSType::Fedora
+            } else if release.distro == Some("deepin".to_string()) {
+                OSType::deepin
+            } else if release.distro == Some("Zorin".to_string()) {
+                OSType::Zorin
             } else {
                 OSType::Unknown
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,9 @@
+use std::collections::HashSet;
 use std::process::Command;
-use std::fs;
 use std::convert::AsRef;
 use std::path::Path;
-use std::collections::HashSet;
+use std::fmt;
+use std::fs;
 
 mod lsb_release;
 mod windows_ver;
@@ -13,11 +14,26 @@ mod windows_ver;
 #[derive(PartialEq)]
 #[derive(Clone)]
 pub enum OSType {
-    Unknown,
-    Redhat,
     Windows,
     OSX,
     Distro(&'static str),
+    Redhat,
+    CentOS,
+    Unknown,
+}
+
+impl fmt::Display for OSType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            OSType::Windows => write!(f, "windows")?,
+            OSType::OSX => write!(f, "OSX")?,
+            OSType::Distro(distro) => write!(f, "{}", distro)?,
+            OSType::Redhat => write!(f, "RedHat")?,
+            OSType::CentOS => write!(f, "CentOS")?,
+            OSType::Unknown => write!(f, "Unknown")?,            
+        };
+        Ok(())
+    }
 }
 
 fn file_exists<P: AsRef<Path>>(path: P) -> bool {
@@ -88,8 +104,10 @@ pub fn current_platform() -> OSType {
         OSType::Windows
     } else if lsb_release::is_available() {
         lsb_release()
-    } else if file_exists("/etc/redhat-release") || file_exists("/etc/centos-release") {
+    } else if file_exists("/etc/redhat-release") {
         OSType::Redhat
+    } else if file_exists("/etc/centos-release") {
+        OSType::CentOS
     } else {
         OSType::Unknown
     }


### PR DESCRIPTION
Up the version to 0.7.0, move distros to a HashSet,Impl Display and To_String for OSType,take apart redhat and centos,Complete top 10 distributions on distrowatch.com.