### PR TITLE
List returned OS types

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,14 @@ fn foo() {
 }
 ```
 
-Right now, the following operating systems are detected:
-
-- Mac OS X
-- CentOS
-- RedHat
+Right now, the following operating system types can be returned:
+- Unknown
+- Redhat
+- OSX
 - Ubuntu
+- Debian
+- Windows
+- Arch
 
 If you need support for more OS types, I am looking forward to your Pull Request.
 


### PR DESCRIPTION
While looking into using this crate I found I had to read the source code to see what types are returned. Which isn't necessarily bad but having a list in the 'readme' makes it a bit easier.