### PR TITLE
chore: update regex version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,4 @@ license = "MIT"
 description = "Detect the operating system type"
 repository = "https://github.com/schultyy/os_type"
 [dependencies]
-regex="0.1.41"
+regex="^0.2.1"

--- a/src/lsb_release.rs
+++ b/src/lsb_release.rs
@@ -28,9 +28,9 @@ pub fn parse(file: String) -> LsbRelease {
 
     let distro = match distrib_regex.captures_iter(&file).next() {
         Some(m) => {
-            match m.at(1) {
+            match m.get(1) {
                 Some(distro) => {
-                    Some(distro.to_string())
+                    Some(distro.as_str().to_owned())
                 },
                 None => None
             }
@@ -40,8 +40,8 @@ pub fn parse(file: String) -> LsbRelease {
 
     let version = match distrib_release_regex.captures_iter(&file).next() {
         Some(m) => {
-            match m.at(1) {
-                Some(version) => Some(version.to_string()),
+            match m.get(1) {
+                Some(version) => Some(version.as_str().to_owned()),
                 None => None
             }
         },

--- a/src/rhel_release.rs
+++ b/src/rhel_release.rs
@@ -38,9 +38,9 @@ pub fn parse(file: String) -> RHELRelease {
 
     let distro = match distrib_regex.captures_iter(&file).next() {
         Some(m) => {
-            match m.at(1) {
+            match m.get(1) {
                 Some(distro) => {
-                    Some(distro.to_string())
+                    Some(distro.as_str().to_owned())
                 },
                 None => None
             }
@@ -50,9 +50,9 @@ pub fn parse(file: String) -> RHELRelease {
 
     let version = match version_regex.captures_iter(&file).next() {
         Some(m) => {
-            match m.at(1) {
+            match m.get(1) {
                 Some(version) => {
-                    Some(version.to_string())
+                    Some(version.as_str().to_owned())
                 },
                 None => None
             }

--- a/src/sw_vers.rs
+++ b/src/sw_vers.rs
@@ -13,9 +13,9 @@ pub struct SwVers {
 fn extract_from_regex(stdout: &String, regex: Regex) -> Option<String> {
     match regex.captures_iter(&stdout).next() {
         Some(m) => {
-            match m.at(1) {
+            match m.get(1) {
                 Some(s) => {
-                    Some(s.to_string())
+                    Some(s.as_str().to_owned())
                 },
                 None => None
             }

--- a/src/windows_ver.rs
+++ b/src/windows_ver.rs
@@ -19,8 +19,8 @@ pub fn parse(output: String) -> WindowsVer {
 
     let version = match version_regex.captures_iter(&output).next() {
         Some(m) => {
-            match m.at(1) {
-                Some(version) => Some(version.to_string()),
+            match m.get(1) {
+                Some(version) => Some(version.as_str().to_owned()),
                 None => None
             }
         },


### PR DESCRIPTION
This updates the regex dependency to version `0.2.1` or later compatible versions. It also addresses a [few breaking changes](https://github.com/rust-lang/regex/blob/master/CHANGELOG.md) that were made to prepare for a regex 1.0 release.