### PR TITLE
Update to regex 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,6 @@ authors = ["Jan Schulte <hello@unexpected-co.de>"]
 license = "MIT"
 description = "Detect the operating system type"
 repository = "https://github.com/schultyy/os_type"
+
 [dependencies]
-regex="^0.2.1"
+regex="1"


### PR DESCRIPTION
## What does this do?
Updates regex dependency to version 1

## Why did you choose this approach?
This is important because it prevents multiple versions of the regex crate being included when someone uses this crate and regex 1.0