### PR TITLE
Alpine suppport

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Right now, the following operating system types can be returned:
 - Debian
 - Arch
 - Manjaro
+- Alpine
 
 If you need support for more OS types, I am looking forward to your Pull Request.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,8 @@ pub enum OSType {
     Arch,
     Manjaro,
     CentOS,
-    OpenSUSE
+    OpenSUSE,
+    Alpine
 }
 
 /// Holds information about Operating System type and its version
@@ -154,6 +155,11 @@ fn os_release() -> OSInformation {
                 } else if distro.starts_with("openSUSE") {
                     OSInformation {
                         os_type: OSType::OpenSUSE,
+                        version: release.version.unwrap_or(default_version()),
+                    }
+                } else if distro.starts_with("Alpine") {
+                    OSInformation {
+                        os_type: OSType::Alpine,
                         version: release.version.unwrap_or(default_version()),
                     }
                 } else {

--- a/src/os_release.rs
+++ b/src/os_release.rs
@@ -35,7 +35,7 @@ pub fn retrieve() -> Option<OSRelease> {
 
 pub fn parse(file: String) -> OSRelease {
     let distrib_regex = Regex::new(r#"NAME="(\w+)"#).unwrap();
-    let version_regex = Regex::new(r#"VERSION_ID="([\w\.]+)"#).unwrap();
+    let version_regex = Regex::new(r#"VERSION_ID="?([\w\.]+)"#).unwrap();
 
     let distro = match distrib_regex.captures_iter(&file).next() {
         Some(m) => match m.get(1) {
@@ -81,6 +81,26 @@ mod tests {
             OSRelease {
                 distro: Some("Ubuntu".to_string()),
                 version: Some("18.04".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_alpine_3_9_5_os_release() {
+        let sample = "\
+        NAME=\"Alpine Linux\"
+        ID=alpine
+        VERSION_ID=3.9.5
+        PRETTY_NAME=\"Alpine Linux v3.9\"
+        HOME_URL=\"https://alpinelinux.org/\"
+        BUG_REPORT_URL=\"https://bugs.alpinelinux.org/\"
+        ".to_string();
+
+        assert_eq!(
+            parse(sample),
+            OSRelease {
+                distro: Some("Alpine".to_string()),
+                version: Some("3.9.5".to_string()),
             }
         );
     }


### PR DESCRIPTION
## What does this do?
Adds support for parsing the os info for Alpine Linux

## Why did you choose this approach?
Alpine doesn't have `lsb_release` by default, so the `/etc/os_release` file was the best choice.

### Note:
The `VERSION_ID` line in Alpine Linux doesn't have quotation marks around it so I modified to regex string to optionally look for the quotation mark.