### PR TITLE
Add Deepin Linux Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Using `os_type::current_platform().os_type`, expect one of these return values:
 - Arch
 - Manjaro
 - Alpine
+- Deepin
 
 If you need support for more OS types, please consider opening a Pull Request.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,8 @@ pub enum OSType {
     Manjaro,
     CentOS,
     OpenSUSE,
-    Alpine
+    Alpine,
+    Deepin,
 }
 
 /// Holds information about Operating System type and its version
@@ -161,6 +162,12 @@ fn os_release() -> OSInformation {
                 else if distro.starts_with("Alpine") {
                     OSInformation {
                         os_type: OSType::Alpine,
+                        version: release.version.unwrap_or(default_version()),
+                    }
+                }
+                else if distro.starts_with("Deepin") {
+                    OSInformation {
+                        os_type: OSType::Deepin,
                         version: release.version.unwrap_or(default_version()),
                     }
                 }

--- a/src/os_release.rs
+++ b/src/os_release.rs
@@ -104,4 +104,24 @@ mod tests {
             }
         );
     }
+    
+    #[test]
+    fn parse_deepin_20_3_os_release() {
+        let sample = "\
+        PRETTY_NAME=\"Deepin 20.3\"
+        NAME=\"Deepin\"
+        VERSION_ID=\"20.3\"
+        VERSION=\"20.3\"
+        ID=Deepin
+        HOME_URL=\"https://www.deepin.org/\"
+        ".to_string();
+
+        assert_eq!(
+            parse(sample),
+            OSRelease {
+                distro: Some("Deepin".to_string()),
+                version: Some("20.3".to_string()),
+            }
+        );
+    }
 }


### PR DESCRIPTION
## What does this do?
add a os type `Deepin` support

---

Hello. I used this rust lib in my linux laptop， but it's failed for get `unknow`。
I add a support and unit test.


