### PR TITLE
docs: add link to section of commit message format

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ This project is intended to be a safe, welcoming space for collaboration, and co
 
 We welcome any kind of contribution: Documentation, code, issues, discussions, critique, speaking about it...
 
-This project follows the [Angular Conventional Commit guidelines](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#-git-commit-guidelines). We require that every commit message follows these guidelines, Pull Requests not following this pattern will be rejected.
+This project follows the [Angular Conventional Commit guidelines](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#-git-commit-guidelines). We require that every commit message follows these [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits), Pull Requests not following this pattern will be rejected.
 
 Unit tests live in the same file inside a [`tests`](https://doc.rust-lang.org/book/second-edition/ch11-01-writing-tests.html) module.
 Integration tests are in `tests/`.


### PR DESCRIPTION
While there is a link to the commit angular guidelines. this additional link points to exact point
where the concrete format of commit message is described.

## What does this do?

For convenience, adds an link to the direct location for the concrete commit message.  

## Why did you choose this approach?

Simple Documentation addition are just changing the text in my view.
